### PR TITLE
docs: add AI doc contracts for issue #20

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Package manager: `npm`
 - Canonical local commands:
   - `npm run lint`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,10 +80,11 @@ Route those tasks to:
 
 - Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Package manager: `npm`
-- Canonical local commands:
+- Required local validation baseline:
   - `npm run lint`
   - `npm run typecheck`
   - `npm run build`
+- Optional local render checks when the task needs page or routing verification:
   - `npm run start`
   - `npm run serve`
 - Release is tag-driven through `v<version>` and deploys the built site to Cloudflare Pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+---
+title: tidas AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: tidas
+language: en
+whenToUse:
+  - when a task may change public TIDAS specification pages, published schema files, or docs-site navigation and localization
+  - when routing work from the workspace root into tidas
+  - when deciding whether a change belongs here, in tidas-tools, in tidas-sdk, or in lca-workspace
+whenToUpdate:
+  - when spec/docs ownership boundaries change
+  - when docs-site runtime or release automation changes
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - package.json
+  - docs/**
+  - static/schemas/**
+  - sidebars.ts
+  - docusaurus.config.ts
+  - i18n/**
+  - src/**
+  - versions.json
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8cece2a553f0d292df61d247fd861d01b627852f
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - README.md
+---
+
+## Repo Contract
+
+`tidas` owns the public TIDAS specification and docs-site surface: Docusaurus pages, published schema downloads, navigation, and localization assets. Start here when the task may change how the spec is explained or published on the site.
+
+## AI Load Order
+
+Load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. `README.md` only for basic site commands
+
+Do not assume executable tooling logic lives here just because the repo publishes schema files.
+
+## Repo Ownership
+
+This repo owns:
+
+- `docs/**` and `src/**` for public spec/docs-site content and components
+- `static/schemas/**` for published downloadable schema files on the site
+- `sidebars.ts`, `docusaurus.config.ts`, and `i18n/**` for navigation, site runtime, and localization
+- the tag-driven Cloudflare Pages release workflow
+
+This repo does not own:
+
+- standalone conversion, validation, or export tooling logic
+- generated SDK package surfaces
+- workspace integration state after merge
+
+Route those tasks to:
+
+- `tidas-tools` for standalone tooling logic and upstream packaged assets
+- `tidas-sdk` for generated package surfaces
+- `lca-workspace` for root integration after merge
+
+## Runtime Facts
+
+- Package manager: `npm`
+- Canonical local commands:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run build`
+  - `npm run start`
+  - `npm run serve`
+- Release is tag-driven through `v<version>` and deploys the built site to Cloudflare Pages
+
+## Hard Boundaries
+
+- Do not treat the docs-site schema download surface as the executable tooling upstream
+- Do not move standalone tooling logic into this repo
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+
+## Workspace Integration
+
+A merged PR in `tidas` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `tidas`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated docs or schema snapshot

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-npm update && npm ci
+npm ci
 ```
 
 ## Error check & fix
@@ -16,13 +16,23 @@ npm run lint:fix
 
 This command will check the code style and fix the code style automatically.
 
-## Local Development
+## Validation Baseline
+
+Run this baseline before opening or updating a PR:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+## Local Development Preview
 
 ```bash
 npm run start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts the local Docusaurus development server for interactive page checks. Use it when the task needs local rendering confirmation; it is not a substitute for the validation baseline above.
 
 ## Build
 
@@ -32,7 +42,7 @@ npm run build
 npm run serve
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+`npm run build` is part of the required validation baseline. `npm run serve` is an optional post-build preview for checking the generated static output locally.
 
 ## Translation
 

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,81 @@
+---
+title: tidas Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas
+language: en
+whenToUse:
+  - when you need a compact mental model of the repo before editing spec pages, schema downloads, or site runtime files
+  - when deciding which site layer owns a behavior change
+  - when spec docs, downloadable schemas, or downstream handoffs are mentioned without exact paths
+whenToUpdate:
+  - when major site layers or localization paths change
+  - when the published-schema surface changes
+  - when downstream handoffs make the current map misleading
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - docs/**
+  - static/schemas/**
+  - sidebars.ts
+  - docusaurus.config.ts
+  - i18n/**
+  - src/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8cece2a553f0d292df61d247fd861d01b627852f
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../README.md
+---
+
+## Repo Shape
+
+This repo is a Docusaurus site that publishes public TIDAS specification content plus downloadable schema files.
+
+## Stable Path Map
+
+| Path group | Role |
+| --- | --- |
+| `docs/**` | public spec, integration, and tooling explanation pages |
+| `static/schemas/**` | published downloadable schema files |
+| `sidebars.ts` | site navigation structure |
+| `docusaurus.config.ts` | site config, locales, and plugin wiring |
+| `i18n/**` | localization assets |
+| `src/**` | site runtime components and custom pages |
+| `.github/workflows/build.yml` | tag-driven Cloudflare Pages deployment |
+
+## Practical Cross-Repo Chain
+
+The practical role split today is:
+
+- `tidas`: public spec/docs surface
+- `tidas-tools`: executable tooling and packaged upstream assets
+- `tidas-sdk`: generated package surfaces
+
+Important consequence:
+
+`static/schemas/**` is a published docs-site surface, not an automatic mirror of `tidas-tools/src/tidas_tools/tidas/schemas/**`.
+
+Treat both surfaces explicitly.
+
+## Site Runtime
+
+The repo uses Docusaurus with localized site assets and can build or serve static output locally through the npm scripts in `package.json`.
+
+## Release Architecture
+
+Tag `v<version>` triggers the site build and a Cloudflare Pages deploy of the `build/` output.
+
+This release path is part of the repo architecture, not just a deployment checklist.
+
+## Common Misreads
+
+- downloadable schema files on the site are not the only executable upstream
+- standalone tooling behavior does not live here
+- generated SDK package output does not live here
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -105,7 +105,7 @@
           "kind": "docs-versioning"
         },
         {
-          "path": ".github/workflows/**",
+          "path": ".github/workflows/build.yml",
           "kind": "automation"
         }
       ],
@@ -132,6 +132,44 @@
         }
       ],
       "reason": "Site runtime, localization, versioning, and deploy changes alter how future docs work should be routed and checked."
+    },
+    {
+      "id": "tidas-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "tidas",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,137 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "8cece2a553f0d292df61d247fd861d01b627852f",
+  "rules": [
+    {
+      "id": "tidas-bootstrap-contract",
+      "scope": "repo",
+      "repo": "tidas",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "tidas-public-spec-contract",
+      "scope": "repo",
+      "repo": "tidas",
+      "triggers": [
+        {
+          "path": "docs/**",
+          "kind": "public-doc"
+        },
+        {
+          "path": "static/schemas/**",
+          "kind": "published-schema"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Public docs and published schema files define the docs-site contract and should refresh the AI bootstrap docs when they change."
+    },
+    {
+      "id": "tidas-site-runtime-contract",
+      "scope": "repo",
+      "repo": "tidas",
+      "triggers": [
+        {
+          "path": "package.json",
+          "kind": "site-runtime"
+        },
+        {
+          "path": "sidebars.ts",
+          "kind": "site-nav"
+        },
+        {
+          "path": "docusaurus.config.ts",
+          "kind": "site-config"
+        },
+        {
+          "path": "i18n/**",
+          "kind": "localization"
+        },
+        {
+          "path": "src/**",
+          "kind": "site-runtime"
+        },
+        {
+          "path": "versions.json",
+          "kind": "docs-versioning"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Site runtime, localization, versioning, and deploy changes alter how future docs work should be routed and checked."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -127,7 +127,7 @@
       "notes": [
         "Use npm run start or npm run serve when the task needs local page rendering verification.",
         "Published schema files under static/schemas are not auto-synced from tidas-tools and should be reviewed explicitly when they change.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,134 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "8cece2a553f0d292df61d247fd861d01b627852f",
+  "repo": {
+    "id": "tidas",
+    "path": "tidas",
+    "canonicalRepo": "tiangong-lca/tidas",
+    "purpose": "Public TIDAS specification and schema documentation site.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch TIDAS spec snapshots when the workspace intends to ship the updated docs-site state.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/tiangong-lca/tidas/issues/20"
+    },
+    "runtime": {
+      "packageManager": "npm",
+      "siteFramework": "Docusaurus",
+      "baselineValidationCommands": [
+        "npm run lint",
+        "npm run typecheck",
+        "npm run build"
+      ],
+      "localReviewCommands": [
+        "npm run start",
+        "npm run serve"
+      ],
+      "releaseTagPattern": "v<version>",
+      "deployTarget": "Cloudflare Pages"
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "docs/**",
+          "role": "public specification and integration documentation"
+        },
+        {
+          "path": "static/schemas/**",
+          "role": "published downloadable schema files served by the docs site"
+        },
+        {
+          "path": "sidebars.ts",
+          "role": "site navigation structure"
+        },
+        {
+          "path": "docusaurus.config.ts",
+          "role": "site config, locales, and plugin wiring"
+        },
+        {
+          "path": "i18n/**",
+          "role": "site localization assets"
+        },
+        {
+          "path": "src/**",
+          "role": "site runtime components and custom pages"
+        },
+        {
+          "path": ".github/workflows/build.yml",
+          "role": "tag-driven Cloudflare Pages deployment"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "tidas-tools",
+          "doesNotOwn": [
+            "standalone conversion CLI",
+            "standalone validation CLI",
+            "packaged upstream schema assets used by tooling"
+          ]
+        },
+        {
+          "repo": "tidas-sdk",
+          "doesNotOwn": [
+            "generated package surfaces"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "public spec and schema docs",
+        "paths": [
+          "docs/core-modules/schema/**",
+          "docs/tool/**",
+          "docs/integration/**"
+        ]
+      },
+      {
+        "topic": "published schema downloads",
+        "paths": [
+          "static/schemas/**"
+        ]
+      },
+      {
+        "topic": "site structure, localization, and deployment",
+        "paths": [
+          "sidebars.ts",
+          "docusaurus.config.ts",
+          "i18n/**",
+          "src/**",
+          ".github/workflows/build.yml"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "npm run lint",
+        "npm run typecheck",
+        "npm run build"
+      ],
+      "notes": [
+        "Use npm run start or npm run serve when the task needs local page rendering verification.",
+        "Published schema files under static/schemas are not auto-synced from tidas-tools and should be reviewed explicitly when they change.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -55,6 +55,7 @@ When working inside `tidas`, load docs in this order:
 | Change site navigation, localization, or site runtime | `sidebars.ts`, `docusaurus.config.ts`, `i18n/**`, `src/**` | `ai/validation.md`, `ai/architecture.md` | This is docs-site structure, not standalone tooling logic. |
 | Change standalone validation, conversion, or export behavior | `tidas-tools`, not this repo | root `ai/task-router.md` | Executable tooling lives in `tidas-tools`. |
 | Change generated SDK package surfaces | `tidas-sdk`, not this repo | root `ai/task-router.md` | Generated packages live downstream in `tidas-sdk`. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,86 @@
+---
+title: tidas Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: tidas
+language: en
+whenToUse:
+  - when you already know the task belongs in tidas but need the right next file or next doc
+  - when deciding whether a change belongs in spec pages, published schema downloads, site structure, or another repo
+  - when routing between docs-site work and handoffs to tidas-tools, tidas-sdk, or lca-workspace
+whenToUpdate:
+  - when new docs-site or schema-publish surfaces appear
+  - when cross-repo boundaries change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - docs/**
+  - static/schemas/**
+  - sidebars.ts
+  - docusaurus.config.ts
+  - i18n/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8cece2a553f0d292df61d247fd861d01b627852f
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../README.md
+---
+
+## Repo Load Order
+
+When working inside `tidas`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `README.md` only for site commands
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change public schema introduction or validation docs | `docs/core-modules/schema/**` | `ai/validation.md`, `ai/architecture.md` | This repo owns the public explanation surface. |
+| Change public tooling guidance pages | `docs/tool/**`, `docs/integration/**`, `docs/use_case/**` | `ai/validation.md`, `ai/architecture.md` | If the actual tool behavior changes, coordinate with `tidas-tools`. |
+| Change downloadable schema files published on the site | `static/schemas/**` | `ai/validation.md`, `ai/architecture.md` | These files are served by the site and must be reviewed explicitly. |
+| Change site navigation, localization, or site runtime | `sidebars.ts`, `docusaurus.config.ts`, `i18n/**`, `src/**` | `ai/validation.md`, `ai/architecture.md` | This is docs-site structure, not standalone tooling logic. |
+| Change standalone validation, conversion, or export behavior | `tidas-tools`, not this repo | root `ai/task-router.md` | Executable tooling lives in `tidas-tools`. |
+| Change generated SDK package surfaces | `tidas-sdk`, not this repo | root `ai/task-router.md` | Generated packages live downstream in `tidas-sdk`. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Treating docs-site schema files as the only executable upstream
+
+`static/schemas/**` is a published download surface. Standalone tooling still depends on packaged assets in `tidas-tools`.
+
+### Fixing tooling behavior only in public docs
+
+If the tool actually changed, route the executable fix to `tidas-tools` and then update the docs here.
+
+### Treating generated SDK surfaces as a docs-site concern
+
+If the package output changed, route the package work to `tidas-sdk`.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. public spec page change plus standalone tooling follow-up
+   - update `tidas`
+   - coordinate with `tidas-tools`
+2. public schema explanation plus SDK package follow-up
+   - update `tidas`
+   - coordinate with `tidas-sdk`
+3. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,66 @@
+---
+title: tidas Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas
+language: en
+whenToUse:
+  - when a tidas change is ready for local validation
+  - when deciding the minimum proof required for docs-site, schema-publish, or release-workflow changes
+  - when writing PR validation notes for tidas work
+whenToUpdate:
+  - when the repo gains new canonical site-check commands
+  - when change categories require different proof
+  - when site deploy or localization behavior changes
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - package.json
+  - docs/**
+  - static/schemas/**
+  - sidebars.ts
+  - docusaurus.config.ts
+  - i18n/**
+  - src/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8cece2a553f0d292df61d247fd861d01b627852f
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../README.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only AI-contract work, the default local baseline is:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Use `npm run start` or `npm run serve` when the task needs local page-render verification.
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `docs/**` content only | `npm run lint`; `npm run build` | run `npm run start` or `npm run serve` when the page has MDX, math, or layout-sensitive content | Public docs correctness is the primary concern here. |
+| `static/schemas/**` | `npm run build`; inspect the touched schema files directly | verify the linked explanatory pages still describe the published schema correctly | These files are not auto-synced from `tidas-tools`. |
+| `sidebars.ts`, `docusaurus.config.ts`, `i18n/**`, or `src/**` | `npm run lint`; `npm run typecheck`; `npm run build` | run `npm run start` if the task changes navigation or runtime rendering | Site structure and localization can break build or routing even when page content is unchanged. |
+| release workflow only | inspect `.github/workflows/build.yml`; run `npm run build` | record any Cloudflare-specific assumptions checked locally | Tag-driven deploy proof happens later in GitHub Actions. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which site commands ran
+2. whether any local render check was performed
+3. whether published schema files changed independently of tooling assets elsewhere

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -55,7 +55,7 @@ Use `npm run start` or `npm run serve` when the task needs local page-render ver
 | `static/schemas/**` | `npm run build`; inspect the touched schema files directly | verify the linked explanatory pages still describe the published schema correctly | These files are not auto-synced from `tidas-tools`. |
 | `sidebars.ts`, `docusaurus.config.ts`, `i18n/**`, or `src/**` | `npm run lint`; `npm run typecheck`; `npm run build` | run `npm run start` if the task changes navigation or runtime rendering | Site structure and localization can break build or routing even when page content is unchanged. |
 | release workflow only | inspect `.github/workflows/build.yml`; run `npm run build` | record any Cloudflare-specific assumptions checked locally | Tag-driven deploy proof happens later in GitHub Actions. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Minimum PR Note Quality
 

--- a/docs/_reference-package.md
+++ b/docs/_reference-package.md
@@ -4,7 +4,7 @@ slug: /reference-package
 sidebar_position: 4
 ---
 
-### 📦 数据资源（Data）
+## 📦 数据资源（Data）
 
 Click this link to open in new tab: <a href="https://github.com/linancn/EF-reference-package-3.1-Correction" target="_blank">EF Reference Package 3.1 Correction</a>
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "lint:fix": "npx markdownlint-cli2 '**/*.md' '#node_modules' --fix"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.8.1",
-    "@docusaurus/preset-classic": "^3.8.1",
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
+    "@docusaurus/theme-classic": "3.8.1",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "docusaurus-json-schema-plugin": "^1.15.0",
@@ -49,5 +50,8 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "webpack": "5.95.0"
   }
 }

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
 type FeatureItem = {
   title: string;
   Img: string;
-  description: JSX.Element;
+  description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
@@ -52,7 +53,7 @@ function Feature({title, Img, description}: FeatureItem) {
   );
 }
 
-export default function HomepageFeatures(): JSX.Element {
+export default function HomepageFeatures() {
   return (
     <section className={styles.features}>
       <div className="container">


### PR DESCRIPTION
Closes tiangong-lca/tidas#20
Closes tiangong-lca/tidas#22

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Fix the repo validation baseline by aligning Docusaurus package versions and the homepage React type annotations.
- Clarify README.md and AGENTS.md so `npm run lint`, `npm run typecheck`, and `npm run build` stay the required validation baseline, while `npm run start` and `npm run serve` remain optional local preview commands.

## Validation
- npm run lint
- npm run typecheck
- npm run build
- node .github/scripts/ai-doc-lint.mjs --mode enforce --files ".github/scripts/ai-doc-lint.mjs,.github/scripts/ai-doc-lint.test.mjs,.github/workflows/ai-doc-lint.yml,AGENTS.md,README.md,ai/architecture.md,ai/doc-impact.yaml,ai/repo.yaml,ai/task-router.md,ai/validation.md,docs/_reference-package.md,package.json,src/components/HomepageFeatures/index.tsx"

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.
