### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 17895b187920ec7052ef7f47c26d25344ae5579f
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "2fe49a50f2d9e5c7925c768e0e3f85eb930055d0"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - src/**
   - versions.json
   - .github/workflows/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 17895b187920ec7052ef7f47c26d25344ae5579f
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 2fe49a50f2d9e5c7925c768e0e3f85eb930055d0
 related:
   - .docpact/config.yaml
   - _docs/agents/repo-validation.md

--- a/_docs/agents/repo-architecture.md
+++ b/_docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - i18n/**
   - src/**
   - .github/workflows/build.yml
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 17895b187920ec7052ef7f47c26d25344ae5579f
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 2fe49a50f2d9e5c7925c768e0e3f85eb930055d0
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/_docs/agents/repo-validation.md
+++ b/_docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - i18n/**
   - src/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 5b0be7c
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 2fe49a50f2d9e5c7925c768e0e3f85eb930055d0
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #25

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/main --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.