### PR TITLE
chore: gate tidas release deploy workflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: edbc10817b174ac1f38ff772ab571973b5b3bd0d
+lastReviewedAt: "2026-05-27"
+lastReviewedCommit: "6a12da6fbb9f796e31bebcec05a3d3d0d7cd5ffd"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,33 @@ on:
       - 'v*'
 
 jobs:
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint docs
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
   release:
+    needs: release-gate
     runs-on: ubuntu-latest
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `README.md` and `_docs/agents/r
 - optional render checks:
   - `npm run start`
   - `npm run serve`
-- release is tag-driven through `v<version>` and deploys the built site to Cloudflare Pages
+- release is tag-driven through `v<version>` and deploys the built site to Cloudflare Pages after the release gate runs `lint`, `typecheck`, and `build`
 
 ## Ownership Boundaries
 
@@ -137,7 +137,7 @@ Important handoff nuance:
 - `static/schemas/**` is a published docs-site surface, not an automatic mirror of packaged upstream assets in `tidas-tools`
 - this repo explains public spec and tooling usage; standalone executable tooling logic stays in `tidas-tools`
 - generated SDK package output stays in `tidas-sdk`
-- the tag-driven `build.yml` workflow deploys the built site to Cloudflare Pages
+- the tag-driven `build.yml` workflow runs the release gate before deploying the built site to Cloudflare Pages
 
 ## Documentation Update Rules
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+---
+title: TIDAS README
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas
+language: en
+whenToUse:
+  - when onboarding to the TIDAS spec site repository
+  - when checking public setup and publish commands
+whenToUpdate:
+  - when public setup, versioning, or publish commands change
+  - when the README no longer reflects the current release workflow
+checkPaths:
+  - README.md
+  - package.json
+  - .github/workflows/build.yml
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 6a12da6fbb9f796e31bebcec05a3d3d0d7cd5ffd
+---
+
 # TIDAS
 
 ## AI Docs Entry
@@ -71,6 +93,8 @@ npm run docusaurus docs:version 0.0.1
 ```
 
 ## Publish
+
+Pushing a `v*` tag runs the release gate (`lint`, `typecheck`, and `build`) before the Cloudflare Pages deploy.
 
 ```bash
 git tag

--- a/_docs/agents/repo-architecture.md
+++ b/_docs/agents/repo-architecture.md
@@ -81,7 +81,7 @@ The repo uses Docusaurus with localized site assets and can build or serve stati
 
 ## Release Architecture
 
-Tag `v<version>` triggers the site build and a Cloudflare Pages deploy of the `build/` output.
+Tag `v<version>` triggers the release gate, which runs `npm run lint`, `npm run typecheck`, and `npm run build` before the Cloudflare Pages deploy of the `build/` output.
 
 This release path is part of the repo architecture, not just a deployment checklist.
 

--- a/_docs/agents/repo-validation.md
+++ b/_docs/agents/repo-validation.md
@@ -57,7 +57,7 @@ Use `npm run start` or `npm run serve` when the task needs local page-render ver
 | `docs/**` content only | `npm run lint`; `npm run build` | run `npm run start` or `npm run serve` when the page has MDX, math, or layout-sensitive content | Public docs correctness is the primary concern here. |
 | `static/schemas/**` | `npm run build`; inspect the touched schema files directly | verify the linked explanatory pages still describe the published schema correctly | These files are a published site surface, not an auto-sync from `tidas-tools`. |
 | `package.json`, `sidebars.ts`, `docusaurus.config.ts`, `i18n/**`, `src/**`, or `versions.json` | `npm run lint`; `npm run typecheck`; `npm run build` | run `npm run start` if the task changes navigation or runtime rendering | Site structure and localization can break build or routing even when page content is unchanged. |
-| release workflow only | inspect `.github/workflows/build.yml`; run `npm run build` | record any Cloudflare-specific or tag-specific assumptions checked locally | Tag-driven deploy proof happens later in GitHub Actions. |
+| release workflow only | inspect `.github/workflows/build.yml`; run `npm run lint`; `npm run typecheck`; `npm run build` | record any Cloudflare-specific or tag-specific assumptions checked locally | Tag-driven deploy proof happens later in GitHub Actions after the release gate passes. |
 | repo docs or docpact config only | `scripts/docpact validate-config --root . --strict`; `scripts/docpact lint --root . --worktree --mode enforce` | perform route checks for affected intent surfaces such as `docs-site`, `published-schemas`, or `proof` | Refresh review metadata even when prose-only docs change. |
 
 ## Minimum PR Note Quality


### PR DESCRIPTION
Closes tiangong-lca/tidas#32

## Summary
- Add a release-gate job before Cloudflare Pages release deploy.
- Run lint, typecheck, and build as release/deploy preconditions.

## Key Decisions
- Keep branch pushes free of standalone remote test gates; release/deploy workflows own release validation.

## Validation
- docpact gate passed during push.
- YAML parse, shell syntax, and staged diff checks passed locally before commit.

## Risks / Rollback
- Release deploy now depends on the build gate.

## Workspace Integration
- Requires lca-workspace submodule pointer update after merge.