### PR TITLE
Gate TIDAS releases with local doc checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "6a12da6fbb9f796e31bebcec05a3d3d0d7cd5ffd"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "7821f1c8f9ea72c4d4096b2e210fe7fcad3d87f5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,15 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: >
-          scripts/docpact lint --root . --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}" --mode enforce
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,25 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Set up Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Run docpact release gate
+        run: scripts/docpact-gate.sh --base origin/main
 
       - name: Install dependencies
         run: npm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The retained internal AI docs live under `_docs/agents/`, not `docs/agents/`, so
 - path-level ownership, routing intents, governed-doc inventory, and lint rules live in `.docpact/config.yaml`
 - minimum proof and preview guidance live in `_docs/agents/repo-validation.md`
 - stable path groups and cross-repo handoffs live in `_docs/agents/repo-architecture.md`
-- repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
+- repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 - the main routing intents are `docs-site`, `published-schemas`, `site-runtime`, `proof`, `repo-docs`, and `root-integration`
 - high-value public-doc subdomains are:
   - `docs/core-modules/schema/**` for schema explanation and validation pages

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ checkPaths:
   - README.md
   - package.json
   - .github/workflows/build.yml
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 6a12da6fbb9f796e31bebcec05a3d3d0d7cd5ffd
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 7821f1c8f9ea72c4d4096b2e210fe7fcad3d87f5
 ---
 
 # TIDAS

--- a/_docs/agents/repo-architecture.md
+++ b/_docs/agents/repo-architecture.md
@@ -94,4 +94,4 @@ This release path is part of the repo architecture, not just a deployment checkl
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; ordinary PRs and pushes rely on the local gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback for remote reproduction.

--- a/_docs/agents/repo-validation.md
+++ b/_docs/agents/repo-validation.md
@@ -75,7 +75,7 @@ The repo's machine-readable governance source is `.docpact/config.yaml`.
 That means:
 
 - governed-doc rules, routing intents, ownership boundaries, coverage, and freshness live in `.docpact/config.yaml`
-- `.github/workflows/ai-doc-lint.yml` should validate config and run `docpact lint`
+- `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback and should delegate to the same local docpact gate
 - retained explanatory docs stay in `AGENTS.md`, this file, `repo-architecture.md`, and `README.md`
 
 ## Local Docpact Push Gate


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate
- add a docpact release gate before Cloudflare Pages deploy

## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #34
