### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "7821f1c8f9ea72c4d4096b2e210fe7fcad3d87f5"
+lastReviewedCommit: "c012afe6479cc90daf28f61152c9407f8a46c6b2"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57"
+lastReviewedCommit: "5becb48dec6045d881621f15d86f82bb3cfd3e0a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "c012afe6479cc90daf28f61152c9407f8a46c6b2"
+lastReviewedCommit: "bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/main
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,11 @@ jobs:
           node-version: '20'
 
       - name: Run docpact release gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: |
+          set -euo pipefail
+          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          release_base="$(git rev-parse "${release_head}^")"
+          scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
 
       - name: Install dependencies
         run: npm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: edbc10817b174ac1f38ff772ab571973b5b3bd0d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
 related:
   - .docpact/config.yaml
   - _docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
+lastReviewedCommit: 5becb48dec6045d881621f15d86f82bb3cfd3e0a
 related:
   - .docpact/config.yaml
   - _docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
+lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
 related:
   - .docpact/config.yaml
   - _docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ checkPaths:
   - package.json
   - .github/workflows/build.yml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
+lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
 ---
 
 # TIDAS

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ checkPaths:
   - package.json
   - .github/workflows/build.yml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 7821f1c8f9ea72c4d4096b2e210fe7fcad3d87f5
+lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
 ---
 
 # TIDAS

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ checkPaths:
   - package.json
   - .github/workflows/build.yml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
+lastReviewedCommit: 5becb48dec6045d881621f15d86f82bb3cfd3e0a
 ---
 
 # TIDAS

--- a/_docs/agents/repo-architecture.md
+++ b/_docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
+lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/_docs/agents/repo-architecture.md
+++ b/_docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
+lastReviewedCommit: 5becb48dec6045d881621f15d86f82bb3cfd3e0a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/_docs/agents/repo-architecture.md
+++ b/_docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: edbc10817b174ac1f38ff772ab571973b5b3bd0d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/_docs/agents/repo-validation.md
+++ b/_docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
+lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/_docs/agents/repo-validation.md
+++ b/_docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: bfe15eaa87ac9891bda76c1f1bacb22e5bbf7b57
+lastReviewedCommit: 5becb48dec6045d881621f15d86f82bb3cfd3e0a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/_docs/agents/repo-validation.md
+++ b/_docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: edbc10817b174ac1f38ff772ab571973b5b3bd0d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: c012afe6479cc90daf28f61152c9407f8a46c6b2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183